### PR TITLE
modified the contact button on homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -391,14 +391,16 @@ const IndexPage = () => (
     <div className="promo promo-light" style={{ marginTop: "-100px" }}>
       <div style={{ width: "75%", marginLeft: "10%" }}>
         <h3>
-          Call Carol at <a href="tel:9257522192">(925) 752-2192</a>
+          Contact Us Today!
         </h3>
         <span>
           We would love for you to come and visit our club anytime!
         </span>
         <a
           style={{ marginRight: "10%" }}
-          href="/contact-us"
+          href="https://ccclub.toastmastersclubs.org/"
+          target="_blank"
+          rel="noreferrer"
           className="button button-xlarge button-rounded"
         >
           Contact Us


### PR DESCRIPTION
modified the contact button on homepage to temporarily point to a different URL, instead of the contact page (until we fix it).  Also, removed Carols name and phone, and replaced it with text